### PR TITLE
Add pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+# Task
+
+[Please include a summary of the changes here]
+
+[Link to Ticket](Insert Link Here)
+
+[Add links to additional documentation if exists. Otherwise, delete this block]
+
+[Insert related tickets here. Otherwise, delete this block]
+
+# Author Tasks
+
+## Acceptance Criteria
+Please include the acceptance criteria from the ticket here or select N/A.
+- [ ] N/A
+


### PR DESCRIPTION
I added a starter pull request template so that we have a standardized way for contributors to include info about the pull request. Anyone can feel free to make changes to the template and open a new PR. This will become more relevant as we go and we can add checks for testing, linting, etc. 