### PR TITLE
default postgres credentials in starter .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-# Set these in your .bashrc or other shell config file
-POSTGRES_USER=$POSTGRES_USER
-POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+# Override these values with your local postgres credentials
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
 
 POSTGRES_DB=incredihire
 STACK_NAME=stack_incredihire


### PR DESCRIPTION
Editing environment variables has proven to be challenging for people unfamiliar with  backend setup, especially for SDETs.  The default postgresql username/password is postgres/postgres so those should be the defaults in the .env file