### PR TITLE
Revert "default postgres credentials in starter .env file"

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-# Override these values with your local postgres credentials
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
+# Set these in your .bashrc or other shell config file
+POSTGRES_USER=$POSTGRES_USER
+POSTGRES_PASSWORD=$POSTGRES_PASSWORD
 
 POSTGRES_DB=incredihire
 STACK_NAME=stack_incredihire


### PR DESCRIPTION
It's a bad idea to include authorization credentials in files checked into github.  Reverting this change.

This reverts commit 667955793a79d93fb0ec1b226c5683f24edcee58.

# Task

[Please include a summary of the changes here]

[Link to Ticket](Insert Link Here)

[Add links to additional documentation if exists. Otherwise, delete this block]

[Insert related tickets here. Otherwise, delete this block]

# Author Tasks

## Acceptance Criteria
Please include the acceptance criteria from the ticket here or select N/A.
- [ ] N/A

