### PR TITLE
Add VS Code debugging configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,34 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Backend: Launch FastAPI Python Debugger",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "uvicorn",
+      "args": ["app.main:app", "--reload"],
+      "cwd": "${workspaceFolder}/backend",
+      "jinja": true,
+      "envFile": "${workspaceFolder}/.env"
+    },
+    {
+      "name": "Debug Frontend: Launch Chrome against http://localhost:5173",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:5173",
+      "webRoot": "${workspaceFolder}/frontend"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Run Backend and Frontend",
+      "configurations": [
+        "Debug Backend: Launch FastAPI Python Debugger",
+        "Debug Frontend: Launch Chrome against http://localhost:5173"
+      ]
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,8 @@
       "args": ["app.main:app", "--reload"],
       "cwd": "${workspaceFolder}/backend",
       "jinja": true,
-      "envFile": "${workspaceFolder}/.env"
+      "envFile": "${workspaceFolder}/.env",
+      "python": "${workspaceFolder}/backend/.venv/bin/python"
     },
     {
       "name": "Debug Frontend: Launch Chrome against http://localhost:5173",


### PR DESCRIPTION
# Task

I added `launch.json` configuration file for Visual Studio Code to enable simultaneous debugging for both the backend (Python FastAPI) and frontend (React). 

[Link to Ticket](https://incredihire-academy.atlassian.net/browse/SR-39?atlOrigin=eyJpIjoiNjUxYzQyNDY2MjFlNGIyOWE2MWY5Yjc2MjdkMzBiYWEiLCJwIjoiaiJ9)

## How to Run the Frontend Debugger

First, navigate to the `frontend` directory and install dependencies by running
```
npm install
```
After the dependencies are installed, you need to launch the frontend application by
```
npm run dev
``` 
With the application running, open the **Run and Debug** panel in Visual Studio Code and select **Debug Frontend** then green start button.

![Screenshot 2024-09-11 135547](https://github.com/user-attachments/assets/4c409aa3-2996-4dcb-b3b8-aa56b0a6b784)

This will launch a Chrome browser pointing to `https://localhost:5173`



## How to Run the Backend Debugger

First, navigate to the `backend` directory. Begin by configuring Poetry to create virtual environment within the project folder.

Check installed poetry environment by running
```
poetry env info
```
This will list path to the virtual environment created by Poetry:
```
➜  backend git:(vscode-debug) ✗ poetry env info

Virtualenv
Python:         3.12.5
Implementation: CPython
Path:           /home/ilhanbae/.cache/pypoetry/virtualenvs/app-6zZbMuyK-py3.12
Executable:     /home/ilhanbae/.cache/pypoetry/virtualenvs/app-6zZbMuyK-py3.12/bin/python
Valid:          True

Base
Platform:   linux
OS:         posix
Python:     3.12.5
Path:       /home/linuxbrew/.linuxbrew/Cellar/python@3.12/3.12.5
Executable: /home/linuxbrew/.linuxbrew/Cellar/python@3.12/3.12.5/bin/python3.12
```

Now this virtual environment needs to be removed, because the path to this folder vary from machine and we need debugger to access these virtual environment in more consistent way. If you don't see any path listed under Virtual env, you can skip this step.

So for my machine, I would do:
```
rm -rf ~/.cache/pypoetry/virtualenvs/app-6zZbMuyK-py3.12/
``` 

To create virtual environment within the project folder run the following in `backend` directory:

```
poetry config virtualenvs.in-project true
```

Then install all dependencies using:
```
poetry install
```

This will create `.venv` folder inside backend directory. You can also verify the virtual environment setup with 
```
poetry env info
```

One this setup is complete, open the **Run and Debug** panel in Visual Studio Code and select **Debug Backend** then green start button.

![Screenshot 2024-09-11 140437](https://github.com/user-attachments/assets/e2fc20e7-7b17-4911-be1e-fa23895e72f5)


## How to Run Both Debuggers Simultaneously

To run both the frontend and backend debuggers at the same time, follow these steps:
1. Navigate to the `frontend` directory run `npm run dev` to start the frontend application.
2. Navigate to the `backend` directory and ensure the virtual environment is configured within the project folder
3. Open **Run and Debug** panel, and select **Run Backend and  Frontend**

# Author Tasks

Create launch.json for VS Code Debugging

## Acceptance Criteria
- [x] The debugger successfully launches both frontend and backend services.
- [x] Breakpoints can be set in both frontend and backend services.
- [x] Variables, call stack can be inspected