### PR TITLE
bugfix: Update OS specific python venv path for VS Code debugger configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {
@@ -13,7 +10,15 @@
       "cwd": "${workspaceFolder}/backend",
       "jinja": true,
       "envFile": "${workspaceFolder}/.env",
-      "python": "${workspaceFolder}/backend/.venv/bin/python"
+      "osx": {
+        "python": "${workspaceFolder}/backend/.venv/bin/python"
+      },
+      "linux": {
+        "python": "${workspaceFolder}/backend/.venv/bin/python"
+      },
+      "windows": {
+        "python": "${workspaceFolder}/backend/.venv/Scripts/python.exe"
+      }
     },
     {
       "name": "Debug Frontend: Launch Chrome against http://localhost:5173",
@@ -25,7 +30,7 @@
   ],
   "compounds": [
     {
-      "name": "Run Backend and Frontend",
+      "name": "Debug Backend and Frontend",
       "configurations": [
         "Debug Backend: Launch FastAPI Python Debugger",
         "Debug Frontend: Launch Chrome against http://localhost:5173"


### PR DESCRIPTION
# Task

Launching VS Code backend debugger on Windows machine failed due to an invalid Python virtual environment path in the configuration.

[Link to Ticket](https://incredihire-academy.atlassian.net/browse/SR-93?atlOrigin=eyJpIjoiMDY5ZmQ3YzIwNTUxNGRhYjlmNmE1NTRjMjI5NTNlYmYiLCJwIjoiaiJ9)

## Author Tasks

I updated `launch.json` configuration to include OS-specific python venv path:
* Windows: `.venv/Scripts/python.exe`
* Linux/MacOS`.venv/bin/python`

I also renamed compound debugger to `Debug Backend and Frontend` for clarity.

Instructions for running debugger can be found [here](https://github.com/Incredihire/Survey/blob/d8898f5778d2a623b27fa908c8e6a7eb61f1f10a/README.md#vs-code-debugging).

## Acceptance Criteria
- [x] Can run backend debugger on Windows
- [x] Can run backend debugger on Linux
- [x] Can run backend debugger on MacOS