### PR TITLE
SR-73 Add backend linting/formatting to pre-commit configuration

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,5 +6,14 @@ pre-commit:
       glob: "*.{js,ts,jsx,tsx}"
       run: npm run lint {staged_files}
       stage_fixed: true
-    backend-check:
-    # backend linting and other
+    backend-lint:
+      root: "backend/"  
+      glob: "*.py"
+      run: poetry run ruff check --select I --fix {staged_files}
+      stage_fixed: true
+    backend-format:
+      root: "backend/"
+      glob: "*.py"
+      run: poetry run ruff format {stage_files}
+      stage_fixed: true
+

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,14 +6,8 @@ pre-commit:
       glob: "*.{js,ts,jsx,tsx}"
       run: npm run lint {staged_files}
       stage_fixed: true
-    backend-lint:
+    backend-check:
       root: "backend/"  
       glob: "*.py"
-      run: poetry run ruff check --select I --fix {staged_files}
+      run: poetry run ruff check --select I --fix {staged_files} && poetry run ruff format {stage_files}
       stage_fixed: true
-    backend-format:
-      root: "backend/"
-      glob: "*.py"
-      run: poetry run ruff format {stage_files}
-      stage_fixed: true
-

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,5 @@
 pre-commit:
-  # parallel: true
+  parallel: true
   commands:
     frontend-check-biome:
       root: "frontend/"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,5 +9,7 @@ pre-commit:
     backend-check:
       root: "backend/"  
       glob: "*.py"
-      run: poetry run ruff check --select I --fix {staged_files} && poetry run ruff format {stage_files}
+      run: |
+        poetry run ruff check --select I --fix {staged_files}
+        poetry run ruff format {staged_files}
       stage_fixed: true


### PR DESCRIPTION
# Task
The backend uses Ruff for formatting and linting. [Ruff](https://docs.astral.sh/ruff/formatter/#sorting-imports) is a really good linter/formatter written in Rust. I updated `lefthook.yml` to include backend formatting and linting. Its mostly using the default Ruff rules. We can configure these by updating the Ruff configuration in `pyproject.toml`.

The pre-commit hook calls the Ruff linter then the formatter. It sorts imports for you, which is nice.

```bash
ruff check --select I --fix
ruff format
```

[Link to Ticket](https://incredihire-academy.atlassian.net/jira/software/c/projects/SR/boards/3?selectedIssue=SR-73)

# Author Tasks

## Acceptance Criteria
Please include the acceptance criteria from the ticket here or select N/A.
- [x] N/A

