### PR TITLE
adding content to FormModal

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "biome check --write --staged --no-errors-on-unmatched --files-ignore-unknown=true ./",
+    "lint:fix": "biome check --fix --unsafe ./",
     "lint:eslint": "eslint",
     "preview": "vite preview",
     "test": "jest",

--- a/frontend/src/components/Common/FormModal.tsx
+++ b/frontend/src/components/Common/FormModal.tsx
@@ -26,6 +26,7 @@ import {
   useForm,
 } from "react-hook-form"
 
+import type React from "react"
 import type { ApiError } from "../../client"
 import useCustomToast from "../../hooks/useCustomToast"
 import { handleError } from "../../utils/showToastOnError"
@@ -60,7 +61,8 @@ export interface FormModalProps<T extends FieldValues> {
   isOpen: boolean
   onClose: () => void
   title: string
-  fields: FieldDefinition<T>[]
+  fields?: FieldDefinition<T>[]
+  content: React.ReactNode
   mutationFn: (data: T) => Promise<void>
   successMessage: string
   queryKeyToInvalidate?: string[]
@@ -72,6 +74,7 @@ const FormModal = <T extends FieldValues>({
   onClose,
   title,
   fields,
+  content,
   mutationFn,
   successMessage,
   queryKeyToInvalidate,
@@ -80,16 +83,18 @@ const FormModal = <T extends FieldValues>({
   const queryClient = useQueryClient()
   const showToast = useCustomToast()
 
-  const defaultValues: DefaultValues<T> = fields.reduce(
-    (acc, field) => {
-      if (field.defaultValue !== undefined) {
-        acc[field.name] = field.defaultValue
-      }
-      return acc
-    },
-    // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
-    {} as DefaultValues<T>,
-  )
+  const defaultValues: DefaultValues<T> = fields
+    ? fields.reduce(
+        (acc, field) => {
+          if (field.defaultValue !== undefined) {
+            acc[field.name] = field.defaultValue
+          }
+          return acc
+        },
+        // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
+        {} as DefaultValues<T>,
+      )
+    : []
 
   const {
     register,
@@ -135,7 +140,8 @@ const FormModal = <T extends FieldValues>({
         <ModalHeader>{title}</ModalHeader>
         <ModalCloseButton />
         <ModalBody pb={6}>
-          {fields.map((field) => {
+          {content && content}
+          {fields?.map((field) => {
             const isError = !!errors[field.name]
             if (field.type === "textarea") {
               // For Textarea

--- a/frontend/src/components/Common/FormModal.tsx
+++ b/frontend/src/components/Common/FormModal.tsx
@@ -61,8 +61,8 @@ export interface FormModalProps<T extends FieldValues> {
   isOpen: boolean
   onClose: () => void
   title: string
-  fields: FieldDefinition<T>[]
-  content: React.ReactNode
+  fields?: FieldDefinition<T>[]
+  content?: React.ReactNode
   mutationFn: (data: T) => Promise<void>
   successMessage: string
   queryKeyToInvalidate?: string[]

--- a/frontend/src/components/Common/FormModal.tsx
+++ b/frontend/src/components/Common/FormModal.tsx
@@ -61,8 +61,8 @@ export interface FormModalProps<T extends FieldValues> {
   isOpen: boolean
   onClose: () => void
   title: string
-  fields?: FieldDefinition<T>[] | Record<PropertyKey, never>
-  content?: React.ReactNode
+  fields: FieldDefinition<T>[]
+  content: React.ReactNode
   mutationFn: (data: T) => Promise<void>
   successMessage: string
   queryKeyToInvalidate?: string[]
@@ -73,8 +73,8 @@ const FormModal = <T extends FieldValues>({
   isOpen,
   onClose,
   title,
-  fields,
-  content,
+  fields = [],
+  content = "",
   mutationFn,
   successMessage,
   queryKeyToInvalidate,
@@ -83,7 +83,7 @@ const FormModal = <T extends FieldValues>({
   const queryClient = useQueryClient()
   const showToast = useCustomToast()
 
-  const defaultValues: FieldDefinition<T> = fields?.reduce(
+  const defaultValues: FieldDefinition<T> = fields.reduce(
     (acc, field) => {
       if (field.defaultValue !== undefined) {
         acc[field.name] = field.defaultValue
@@ -138,8 +138,8 @@ const FormModal = <T extends FieldValues>({
         <ModalHeader>{title}</ModalHeader>
         <ModalCloseButton />
         <ModalBody pb={6}>
-          {content && content}
-          {fields?.map((field) => {
+          {content}
+          {fields.map((field) => {
             const isError = !!errors[field.name]
             if (field.type === "textarea") {
               // For Textarea

--- a/frontend/src/components/Common/FormModal.tsx
+++ b/frontend/src/components/Common/FormModal.tsx
@@ -83,17 +83,16 @@ const FormModal = <T extends FieldValues>({
   const queryClient = useQueryClient()
   const showToast = useCustomToast()
 
-  const defaultValues: FieldDefinition<T> =
-    fields?.reduce(
-      (acc, field) => {
-        if (field.defaultValue !== undefined) {
-          acc[field.name] = field.defaultValue
-        }
-        return acc
-      },
-      // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
-      {} as DefaultValues<T>,
-    ) || {}
+  const defaultValues: FieldDefinition<T> = fields?.reduce(
+    (acc, field) => {
+      if (field.defaultValue !== undefined) {
+        acc[field.name] = field.defaultValue
+      }
+      return acc
+    },
+    // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
+    {} as DefaultValues<T>,
+  )
 
   const {
     register,

--- a/frontend/src/components/Common/FormModal.tsx
+++ b/frontend/src/components/Common/FormModal.tsx
@@ -83,7 +83,7 @@ const FormModal = <T extends FieldValues>({
   const queryClient = useQueryClient()
   const showToast = useCustomToast()
 
-  const defaultValues: FieldDefinition<T> = fields.reduce(
+  const defaultValues: DefaultValues<T> = fields.reduce(
     (acc, field) => {
       if (field.defaultValue !== undefined) {
         acc[field.name] = field.defaultValue

--- a/frontend/src/components/Common/FormModal.tsx
+++ b/frontend/src/components/Common/FormModal.tsx
@@ -61,8 +61,8 @@ export interface FormModalProps<T extends FieldValues> {
   isOpen: boolean
   onClose: () => void
   title: string
-  fields?: FieldDefinition<T>[]
-  content: React.ReactNode
+  fields?: FieldDefinition<T>[] | Record<PropertyKey, never>
+  content?: React.ReactNode
   mutationFn: (data: T) => Promise<void>
   successMessage: string
   queryKeyToInvalidate?: string[]
@@ -83,18 +83,17 @@ const FormModal = <T extends FieldValues>({
   const queryClient = useQueryClient()
   const showToast = useCustomToast()
 
-  const defaultValues: DefaultValues<T> = fields
-    ? fields.reduce(
-        (acc, field) => {
-          if (field.defaultValue !== undefined) {
-            acc[field.name] = field.defaultValue
-          }
-          return acc
-        },
-        // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
-        {} as DefaultValues<T>,
-      )
-    : []
+  const defaultValues: FieldDefinition<T> =
+    fields?.reduce(
+      (acc, field) => {
+        if (field.defaultValue !== undefined) {
+          acc[field.name] = field.defaultValue
+        }
+        return acc
+      },
+      // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
+      {} as DefaultValues<T>,
+    ) || {}
 
   const {
     register,

--- a/frontend/src/components/Inquiries/AddInquiry.tsx
+++ b/frontend/src/components/Inquiries/AddInquiry.tsx
@@ -1,5 +1,6 @@
 import type { InquiryCreate } from "../../client/models"
 import { InquiriesService } from "../../client/services"
+// import { isValidUnicode } from "../../utils/validation"
 import FormModal from "../Common/FormModal"
 
 export const MIN_INQUIRY_LENGTH = 10

--- a/frontend/src/components/Inquiries/AddInquiry.tsx
+++ b/frontend/src/components/Inquiries/AddInquiry.tsx
@@ -11,6 +11,32 @@ interface AddInquiryProps {
 }
 
 const AddInquiry = ({ isOpen, onClose }: AddInquiryProps) => {
+  /*
+    const fields: FieldDefinition<InquiryCreate>[] = [
+    {
+      name: "text",
+      label: "Inquiry Text",
+      placeholder: "Enter the text of your inquiry.",
+      type: "textarea",
+      validation: {
+        required: "Inquiry text is required.",
+        minLength: {
+          value: MIN_INQUIRY_LENGTH,
+          message: `Inquiry must be at least ${MIN_INQUIRY_LENGTH} characters.`,
+        },
+        maxLength: {
+          value: MAX_INQUIRY_LENGTH,
+          message: `Inquiry can not be greater than ${MAX_INQUIRY_LENGTH} characters.`,
+        },
+        validate: (value: string) =>
+          isValidUnicode(value) || "Inquiry must be a valid unicode string.",
+      },
+      inputProps: {
+        "data-testid": "add-inquiry-text",
+      },
+    },
+  ]
+  */
   const mutationFn = async (data: InquiryCreate): Promise<void> => {
     await InquiriesService.inquiriesCreateInquiry({ requestBody: data })
   }

--- a/frontend/src/components/Inquiries/AddInquiry.tsx
+++ b/frontend/src/components/Inquiries/AddInquiry.tsx
@@ -1,7 +1,6 @@
 import type { InquiryCreate } from "../../client/models"
 import { InquiriesService } from "../../client/services"
-import { isValidUnicode } from "../../utils/validation"
-import FormModal, { type FieldDefinition } from "../Common/FormModal"
+import FormModal from "../Common/FormModal"
 
 export const MIN_INQUIRY_LENGTH = 10
 export const MAX_INQUIRY_LENGTH = 256
@@ -12,41 +11,16 @@ interface AddInquiryProps {
 }
 
 const AddInquiry = ({ isOpen, onClose }: AddInquiryProps) => {
-  const fields: FieldDefinition<InquiryCreate>[] = [
-    {
-      name: "text",
-      label: "Inquiry Text",
-      placeholder: "Enter the text of your inquiry.",
-      type: "textarea",
-      validation: {
-        required: "Inquiry text is required.",
-        minLength: {
-          value: MIN_INQUIRY_LENGTH,
-          message: `Inquiry must be at least ${MIN_INQUIRY_LENGTH} characters.`,
-        },
-        maxLength: {
-          value: MAX_INQUIRY_LENGTH,
-          message: `Inquiry can not be greater than ${MAX_INQUIRY_LENGTH} characters.`,
-        },
-        validate: (value: string) =>
-          isValidUnicode(value) || "Inquiry must be a valid unicode string.",
-      },
-      inputProps: {
-        "data-testid": "add-inquiry-text",
-      },
-    },
-  ]
-
   const mutationFn = async (data: InquiryCreate): Promise<void> => {
     await InquiriesService.inquiriesCreateInquiry({ requestBody: data })
   }
-
+  const content = "Why do birds suddenly appear every time you are near?"
   return (
     <FormModal<InquiryCreate>
       isOpen={isOpen}
       onClose={onClose}
-      title="Add Inquiry"
-      fields={fields}
+      title="Why birds?"
+      content={content}
       mutationFn={mutationFn}
       successMessage="Inquiry created successfully."
       queryKeyToInvalidate={["inquiries"]}

--- a/frontend/src/routes/_layout/inquiries.tsx
+++ b/frontend/src/routes/_layout/inquiries.tsx
@@ -3,7 +3,7 @@ import { createFileRoute } from "@tanstack/react-router"
 import { z } from "zod"
 
 import Navbar from "../../components/Common/Navbar"
-import AddInquiry from "../../components/Inquiries/AddInquiry.tsx"
+import AddInquiry from "../../components/Inquiries/AddInquiry"
 import InquiriesTable from "../../components/Inquiries/InquiriesTable.tsx"
 import TimerPanel from "../../components/TimerPanel/TimerPanel.tsx"
 

--- a/frontend/src/routes/_layout/inquiries.tsx
+++ b/frontend/src/routes/_layout/inquiries.tsx
@@ -3,7 +3,7 @@ import { createFileRoute } from "@tanstack/react-router"
 import { z } from "zod"
 
 import Navbar from "../../components/Common/Navbar"
-import AddInquiry from "../../components/Inquiries/AddInquiry"
+import AddInquiry from "../../components/Inquiries/AddInquiry.tsx"
 import InquiriesTable from "../../components/Inquiries/InquiriesTable.tsx"
 import TimerPanel from "../../components/TimerPanel/TimerPanel.tsx"
 


### PR DESCRIPTION
Adds `content` Parameter to FormModal so that it can display any ReactNode in addition to or instead of FormFields

Hit the `Add Inquiry` button to see a demo.
![WhyBirds](https://github.com/user-attachments/assets/697173cc-897f-4f85-a714-2024318f82b6)

# Task

[Please include a summary of the changes here]

[Link to Ticket](Insert Link Here)

[Add links to additional documentation if exists. Otherwise, delete this block]

[Insert related tickets here. Otherwise, delete this block]

# Author Tasks

## Acceptance Criteria
Please include the acceptance criteria from the ticket here or select N/A.
- [ ] N/A

