### PR TITLE
Add git attributes to enforce LF line ending for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
# Task

Our app contains shell scripts (e.g. `prestart.sh`) that require LF line (`\n`) endings to run correctly inside the Docker container. If you're working on Windows, Git may automatically convert LF line endings to CRLF (`\r\n`) when `core.autocrlf` is enabled.

[Link to Ticket](https://incredihire-academy.atlassian.net/browse/SR-95?atlOrigin=eyJpIjoiZjE3MTRlZTU4ZjRmNDYwZGI3N2M2NzM5YTg4OTYxNGEiLCJwIjoiaiJ9)

# Author Tasks

I added a git rule to enforce LF line endings for `.sh` files. If you have already cloned the repository, you may have to reset your local project files to see the changes:
```bash
git rm --cached -r .
git reset --hard
```