### PR TITLE
SR-48 making the edit button always visible - task https://incredihir…

### DIFF
--- a/frontend/__tests__/inquiry/inquiries_table.test.tsx
+++ b/frontend/__tests__/inquiry/inquiries_table.test.tsx
@@ -435,4 +435,27 @@ describe("Inquiries Table", () => {
       expect(deleteInquiryRejected).toHaveBeenCalled()
     })
   })
+
+  it("should display an Edit button for scheduled inquiry in the list", async () => {
+    mockUseInquiries.mockReturnValue({
+      data: { data: multipleInquiries },
+      isLoading: false,
+    })
+
+    renderComponent()
+
+    const table = await screen.findByRole("table")
+
+    // Get all rowGroup elements (header + data rows)
+    const rowGroups = within(table).getAllByRole("rowgroup")
+
+    // Data rows are in the second rowGroup (index 1)
+    const dataRowGroup = rowGroups[1]
+
+    const rows = dataRowGroup.querySelectorAll("tr")
+    for (const row of rows) {
+      const editButton = within(row).queryByTestId("edit-inquiry-button")
+      expect(editButton).toBeInTheDocument()
+    }
+  })
 })

--- a/frontend/src/components/ScheduledInquiries/AddScheduledInquiry.tsx
+++ b/frontend/src/components/ScheduledInquiries/AddScheduledInquiry.tsx
@@ -107,11 +107,11 @@ const AddScheduledInquiry = ({
         inquiry={inquiry}
         themes={themes}
       />
-      {!inquiry.first_scheduled && (
+      {
         <Button data-testid={"edit-inquiry-button"} onClick={openUpdateModal}>
           <FiEdit2 />
         </Button>
-      )}
+      }
       {rank > 0 && (
         <Button
           onClick={() => {


### PR DESCRIPTION
…e-academy.atlassian.net/browse/SR-48

# Task

making the edit button always visible instead of hidden if the inquiry had been added to the schedule. it only depends on the frontend because there is no backend validation to determine whether editing scheduled inquiries is allowed.

[[Link to Ticket]](https://incredihire-academy.atlassian.net/browse/SR-48)



# Author Tasks

## Acceptance Criteria
Please include the acceptance criteria from the ticket here or select N/A.
- [ ] N/A

