### PR TITLE
SR-152-User-should-be-able-to-log-into-Survey-via-the-OSX-app and SR-85-Display the current Inquiry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,6 @@ OIDC_ISSUER=https://accounts.google.com
 OIDC_REDIRECT_URI=https://survey-api/api/v1/auth/callback
 OIDC_CLIENT_ID=
 OIDC_CLIENT_SECRET=
+OIDC_REDIRECT_URI_DESKTOP=https://survey-api/api/v1/auth/callback
+OIDC_CLIENT_ID_DESKTOP=
+OIDC_CLIENT_SECRET_DESKTOP=

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -59,7 +59,7 @@ def get_current_user(session: SessionDep, authorization: AuthorizationDep) -> Us
     user = users_service.get_user_by_email(session=session, email=payload.get("email"))
     if not user:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+            status_code=status.HTTP_403_FORBIDDEN, detail="User not found"
         )
     if not user.is_active:
         raise HTTPException(

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -7,8 +7,9 @@ from urllib.parse import urlparse, urlunparse
 import httpx
 import tldextract
 from dotenv import load_dotenv
-from fastapi import APIRouter, HTTPException, Request, status
-from fastapi.responses import RedirectResponse
+from fastapi import APIRouter, Form, HTTPException, Request, status
+from fastapi.responses import JSONResponse, RedirectResponse
+from typing_extensions import Annotated
 
 from app.core.config import settings
 from app.core.security import authorization_endpoint, token_endpoint
@@ -126,4 +127,41 @@ async def callback(request: Request, code: str, state: str) -> RedirectResponse:
         secure=COOKIE_SECURE,
         domain=COOKIE_DOMAIN,
     )
+    return response
+
+
+@router.post("/token/desktop")
+async def token(
+    code: Annotated[str, Form()] = None,
+    refresh_token: Annotated[str, Form()] = None,
+    grant_type: Annotated[str, Form()] = None,
+    scope: Annotated[str, Form()] = None,
+    code_verifier: Annotated[str, Form()] = None,
+) -> JSONResponse:
+    data = {
+        "redirect_uri": settings.OIDC_REDIRECT_URI_DESKTOP,
+        "client_id": settings.OIDC_CLIENT_ID_DESKTOP,
+        "client_secret": settings.OIDC_CLIENT_SECRET_DESKTOP,
+    }
+    if code:
+        data["code"] = code
+    if refresh_token:
+        data["refresh_token"] = code
+    if grant_type:
+        data["grant_type"] = grant_type
+    if scope:
+        data["scope"] = scope
+    if code_verifier:
+        data["code_verifier"] = code_verifier
+    async with httpx.AsyncClient() as client:
+        token_response = await client.post(
+            token_endpoint,
+            data=data,
+        )
+        response_data = token_response.json()
+    if token_response.status_code != 200:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid token request"
+        )
+    response = JSONResponse(response_data)
     return response

--- a/backend/app/api/routes/inquiries.py
+++ b/backend/app/api/routes/inquiries.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException
 
 import app.services.inquiries as inquiries_service
+import app.services.schedule as schedule_service
 from app.api.deps import SessionDep
 from app.models import Inquiry, InquiryCreate, InquiryPublic, InquriesPublic, Message
 from app.models.inquiry import InquiryUpdate
@@ -67,6 +68,21 @@ def get_inquries(
     count = inquiries_service.count_inquiries(session=session)
     inquiries = inquiries_service.get_inquiries(session=session, skip=skip, limit=limit)
     return InquriesPublic(data=inquiries, count=count)
+
+
+@router.get("/current", response_model=InquiryPublic)
+def current_inquiry(session: SessionDep) -> Inquiry:
+    schedule = schedule_service.get_schedule(session)
+    try:
+        inquiry_id = schedule.scheduled_inquiries_and_dates.inquiries[0]
+    except IndexError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    inquiry = inquiries_service.get_inquiry_by_id(
+        session=session, inquiry_id=inquiry_id
+    )
+    if not inquiry:
+        raise HTTPException(status_code=404, detail="Current inquiry not found")
+    return inquiry
 
 
 @router.get("/{inquiry_id}", response_model=InquiryPublic)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -56,6 +56,8 @@ class Settings(BaseSettings):
     OIDC_ISSUER: str = ""
     OIDC_REDIRECT_URI: str = ""
     OIDC_CLIENT_ID_DESKTOP: str = ""
+    OIDC_CLIENT_SECRET_DESKTOP: str = ""
+    OIDC_REDIRECT_URI_DESKTOP: str = ""
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/deployment.md
+++ b/deployment.md
@@ -145,10 +145,11 @@ You can set several variables, like:
 * `OPENID_CONNECT_URL`: The OpenID Connect URL i.e. `https://accounts.google.com/.well-known/openid-configuration`
 * `OIDC_ISSUER`: The OpenID Connect issuer i.e. `https://accounts.google.com`
 * `OIDC_REDIRECT_URI`: The OpenID Connect redirect URI for the web application i.e. `https://survey-api.incredihire.com/api/v1/auth/callback`
-* `OIDC_CLIENT_ID`: The OpenID Connect client ID for the web application.
-* `OIDC_CLIENT_SECRET`: The OpenID Connect client secret for the web application.
-* `OIDC_CLIENT_ID_DESKTOP`: The OpenID Connect client ID for the desktop application.
-
+* `OIDC_CLIENT_ID`: The OpenID Connect client ID for the web application i.e. `0123456789012-abcdef3456g7hi89jk0lm12nop34qr5s.apps.googleusercontent.com`
+* `OIDC_CLIENT_SECRET`: The OpenID Connect client secret for the web application i.e. `ABCDEF-GHIj0kLMN1p23QRSTuv4wxYzaBcD`
+* `OIDC_CLIENT_ID_DESKTOP`: The OpenID Connect client ID for the desktop application i.e. `0123456789012-abcdef3456g7hi89jk0lm12nop34qr5s.apps.googleusercontent.com`
+* `OIDC_CLIENT_SECRET_DESKTOP`: The OpenID Connect client secret for the desktop application i.e. `ABCDEF-GHIj0kLMN1p23QRSTuv4wxYzaBcD`
+* `OIDC_REDIRECT_URI_DESKTOP`: The OpenID Connect redirect URI for the desktop application i.e. `com.googleusercontent.apps.0123456789012-abcdef3456g7hi89jk0lm12nop34qr5s:/auth/callback`
 
 ## GitHub Actions Environment Variables
 


### PR DESCRIPTION


# Task

https://incredihire-academy.atlassian.net/browse/SR-152
added OIDC_CLIENT_SECRET_DESKTOP OIDC_REDIRECT_URI_DESKTOP server env configs, added /api/v1/auth/token/desktop OIDC proxy endpoint with access to desktop app secret,  request with user not found returns 403 instead of 404 now

https://incredihire-academy.atlassian.net/browse/SR-85 
added /inquiries/current api endpoint

## Acceptance Criteria
- [ ] OSX App Login works as expected and displays current inquiry after login

